### PR TITLE
feat(chart-web-components): add FunnelChart web component

### DIFF
--- a/packages/charts/chart-web-components/src/funnel-chart/define.ts
+++ b/packages/charts/chart-web-components/src/funnel-chart/define.ts
@@ -1,0 +1,5 @@
+import { FluentDesignSystem } from '@fluentui/web-components';
+import '../chart-legend/define.js';
+import { definition } from './funnel-chart.definition.js';
+
+definition.define(FluentDesignSystem.registry);

--- a/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.bench.ts
+++ b/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.bench.ts
@@ -1,0 +1,12 @@
+import { FluentDesignSystem } from '@fluentui/web-components';
+import { definition } from './funnel-chart.definition.js';
+
+definition.define(FluentDesignSystem.registry);
+
+const itemRenderer = () => {
+  const funnelChart = document.createElement('fluent-funnel-chart');
+  return funnelChart;
+};
+
+export default itemRenderer;
+export { tests } from '../utils/benchmark-wrapper.js';

--- a/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.definition.ts
+++ b/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.definition.ts
@@ -1,0 +1,18 @@
+import { FluentDesignSystem } from '@fluentui/web-components';
+import { FunnelChart } from './funnel-chart.js';
+import { styles } from './funnel-chart.styles.js';
+import { template } from './funnel-chart.template.js';
+
+/**
+ * @public
+ * @remarks
+ * HTML Element: `<fluent-funnel-chart>`
+ */
+export const definition = FunnelChart.compose({
+  name: `${FluentDesignSystem.prefix}-funnel-chart`,
+  template,
+  styles,
+  shadowOptions: {
+    delegatesFocus: true,
+  },
+});

--- a/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.options.ts
+++ b/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.options.ts
@@ -1,0 +1,48 @@
+/**
+ * A single sub-value within a stacked funnel stage.
+ *
+ * @public
+ */
+export interface FunnelSubValue {
+  /** Category label for this sub-value. */
+  category: string;
+  /** Numeric value for this sub-value. */
+  value: number;
+  /** Fill color for this sub-value. */
+  color: string;
+}
+
+/**
+ * A single stage (segment) in a funnel chart.
+ * Either `value` + `color` (simple funnel) or `subValues` (stacked funnel) must be provided.
+ *
+ * @public
+ */
+export interface FunnelDataPoint {
+  /**
+   * Stage name or identifier, shown in legends and tooltips.
+   */
+  stage: string;
+
+  /**
+   * Numeric value for a non-stacked stage.
+   */
+  value?: number;
+
+  /**
+   * Fill color for a non-stacked stage.
+   */
+  color?: string;
+
+  /**
+   * Sub-values for a stacked funnel stage.
+   */
+  subValues?: FunnelSubValue[];
+}
+
+/**
+ * Orientation of the funnel chart.
+ *
+ * @public
+ */
+export type FunnelOrientation = 'vertical' | 'horizontal';

--- a/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.spec.ts
+++ b/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.spec.ts
@@ -1,6 +1,5 @@
 import { test } from '@playwright/test';
 import { expect, fixtureURL } from '../helpers.tests.js';
-import type { FunnelChart as FluentFunnelChart } from './funnel-chart.js';
 import type { FunnelDataPoint } from './funnel-chart.options.js';
 
 const simpleData: FunnelDataPoint[] = [
@@ -132,6 +131,29 @@ test.describe('FunnelChart - Horizontal', () => {
     const element = page.locator('fluent-funnel-chart');
     const segments = element.locator('.funnel-segment');
     await expect(segments).toHaveCount(simpleData.length);
+  });
+
+  test('Should mirror horizontal segment direction in RTL mode', async ({ page }) => {
+    await page.setContent(/* html */ `
+      <div dir="rtl">
+        <fluent-funnel-chart
+          chart-title="Horizontal RTL funnel"
+          width="600"
+          height="300"
+          orientation="horizontal"
+          data='${JSON.stringify(simpleData)}'
+        ></fluent-funnel-chart>
+      </div>
+    `);
+    await page.waitForFunction(() => customElements.whenDefined('fluent-funnel-chart'));
+
+    const element = page.locator('fluent-funnel-chart');
+    const segments = element.locator('.funnel-segment');
+    const firstSegmentPath = await segments.nth(0).getAttribute('d');
+    const lastSegmentPath = await segments.nth(simpleData.length - 1).getAttribute('d');
+
+    expect(firstSegmentPath).toContain('M360,');
+    expect(lastSegmentPath).toContain('M0,');
   });
 });
 

--- a/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.spec.ts
+++ b/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.spec.ts
@@ -1,0 +1,190 @@
+import { test } from '@playwright/test';
+import { expect, fixtureURL } from '../helpers.tests.js';
+import type { FunnelChart as FluentFunnelChart } from './funnel-chart.js';
+import type { FunnelDataPoint } from './funnel-chart.options.js';
+
+const simpleData: FunnelDataPoint[] = [
+  { stage: 'Impressions', value: 8000, color: '#637cef' },
+  { stage: 'Clicks', value: 4000, color: '#e3008c' },
+  { stage: 'Leads', value: 1500, color: '#2aa0a4' },
+  { stage: 'Conversions', value: 600, color: '#9373c0' },
+];
+
+const stackedData: FunnelDataPoint[] = [
+  {
+    stage: 'Awareness',
+    subValues: [
+      { category: 'Organic', value: 5000, color: '#637cef' },
+      { category: 'Paid', value: 3000, color: '#e3008c' },
+    ],
+  },
+  {
+    stage: 'Interest',
+    subValues: [
+      { category: 'Organic', value: 3000, color: '#637cef' },
+      { category: 'Paid', value: 2000, color: '#e3008c' },
+    ],
+  },
+  {
+    stage: 'Decision',
+    subValues: [
+      { category: 'Organic', value: 1200, color: '#637cef' },
+      { category: 'Paid', value: 800, color: '#e3008c' },
+    ],
+  },
+  {
+    stage: 'Purchase',
+    subValues: [
+      { category: 'Organic', value: 500, color: '#637cef' },
+      { category: 'Paid', value: 300, color: '#e3008c' },
+    ],
+  },
+];
+
+test.describe('FunnelChart - Basic', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(fixtureURL('components-funnelchart--basic'));
+    await page.setContent(/* html */ `
+      <div>
+        <fluent-funnel-chart
+          chart-title="Test funnel"
+          width="350"
+          height="400"
+          data='${JSON.stringify(simpleData)}'
+        ></fluent-funnel-chart>
+      </div>
+    `);
+    await page.waitForFunction(() => customElements.whenDefined('fluent-funnel-chart'));
+  });
+
+  test('Should render chart title', async ({ page }) => {
+    const element = page.locator('fluent-funnel-chart');
+    await expect(element.locator('.chart-title')).toContainText('Test funnel');
+  });
+
+  test('Should render correct number of segments', async ({ page }) => {
+    const element = page.locator('fluent-funnel-chart');
+    const segments = element.locator('.funnel-segment');
+    await expect(segments).toHaveCount(simpleData.length);
+  });
+
+  test('Should render segments with correct fill colors', async ({ page }) => {
+    const element = page.locator('fluent-funnel-chart');
+    const segments = element.locator('.funnel-segment');
+    await expect(segments.nth(0)).toHaveAttribute('fill', '#637cef');
+    await expect(segments.nth(1)).toHaveAttribute('fill', '#e3008c');
+    await expect(segments.nth(2)).toHaveAttribute('fill', '#2aa0a4');
+    await expect(segments.nth(3)).toHaveAttribute('fill', '#9373c0');
+  });
+
+  test('Should render segments with aria-label', async ({ page }) => {
+    const element = page.locator('fluent-funnel-chart');
+    const segments = element.locator('.funnel-segment');
+    await expect(segments.nth(0)).toHaveAttribute('aria-label', 'Impressions, 8000.');
+    await expect(segments.nth(1)).toHaveAttribute('aria-label', 'Clicks, 4000.');
+  });
+
+  test('Should render legend items', async ({ page }) => {
+    const element = page.locator('fluent-funnel-chart');
+    const legends = element.locator('.legend-text');
+    await expect(legends.nth(0).getByText('Impressions')).toBeVisible();
+    await expect(legends.nth(1).getByText('Clicks')).toBeVisible();
+    await expect(legends.nth(2).getByText('Leads')).toBeVisible();
+    await expect(legends.nth(3).getByText('Conversions')).toBeVisible();
+  });
+
+  test('Should hide legends when hide-legends is set', async ({ page }) => {
+    await page.setContent(/* html */ `
+      <div>
+        <fluent-funnel-chart
+          chart-title="Test funnel"
+          width="350"
+          height="400"
+          data='${JSON.stringify(simpleData)}'
+          hide-legends
+        ></fluent-funnel-chart>
+      </div>
+    `);
+    await page.waitForFunction(() => customElements.whenDefined('fluent-funnel-chart'));
+    const element = page.locator('fluent-funnel-chart');
+    await expect(element.locator('fluent-chart-legend')).toBeHidden();
+  });
+});
+
+test.describe('FunnelChart - Horizontal', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(fixtureURL('components-funnelchart--horizontal'));
+    await page.setContent(/* html */ `
+      <div>
+        <fluent-funnel-chart
+          chart-title="Horizontal funnel"
+          width="600"
+          height="300"
+          orientation="horizontal"
+          data='${JSON.stringify(simpleData)}'
+        ></fluent-funnel-chart>
+      </div>
+    `);
+    await page.waitForFunction(() => customElements.whenDefined('fluent-funnel-chart'));
+  });
+
+  test('Should render correct number of segments in horizontal mode', async ({ page }) => {
+    const element = page.locator('fluent-funnel-chart');
+    const segments = element.locator('.funnel-segment');
+    await expect(segments).toHaveCount(simpleData.length);
+  });
+});
+
+test.describe('FunnelChart - Stacked', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(fixtureURL('components-funnelchart--stacked'));
+    await page.setContent(/* html */ `
+      <div>
+        <fluent-funnel-chart
+          chart-title="Stacked funnel"
+          width="350"
+          height="400"
+          data='${JSON.stringify(stackedData)}'
+        ></fluent-funnel-chart>
+      </div>
+    `);
+    await page.waitForFunction(() => customElements.whenDefined('fluent-funnel-chart'));
+  });
+
+  test('Should render correct number of stacked segments', async ({ page }) => {
+    const element = page.locator('fluent-funnel-chart');
+    const segments = element.locator('.funnel-segment');
+    // 4 stages × 2 sub-values
+    await expect(segments).toHaveCount(8);
+  });
+
+  test('Should render stacked legend items', async ({ page }) => {
+    const element = page.locator('fluent-funnel-chart');
+    const legends = element.locator('.legend-text');
+    await expect(legends.nth(0).getByText('Organic')).toBeVisible();
+    await expect(legends.nth(1).getByText('Paid')).toBeVisible();
+  });
+});
+
+test.describe('FunnelChart - Legend interaction', () => {
+  test('Should dim other segments when a legend is hovered', async ({ page }) => {
+    await page.setContent(/* html */ `
+      <div>
+        <fluent-funnel-chart
+          chart-title="Test funnel"
+          width="350"
+          height="400"
+          data='${JSON.stringify(simpleData)}'
+        ></fluent-funnel-chart>
+      </div>
+    `);
+    await page.waitForFunction(() => customElements.whenDefined('fluent-funnel-chart'));
+    const element = page.locator('fluent-funnel-chart');
+    const firstLegend = element.locator('.legend-text').nth(0);
+    await firstLegend.hover();
+
+    const segments = element.locator('.funnel-segment');
+    await expect(segments.nth(0)).not.toHaveClass(/inactive/);
+    await expect(segments.nth(1)).toHaveClass(/inactive/);
+  });
+});

--- a/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.spec.ts
+++ b/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.spec.ts
@@ -152,7 +152,9 @@ test.describe('FunnelChart - Horizontal', () => {
     const firstSegmentPath = await segments.nth(0).getAttribute('d');
     const lastSegmentPath = await segments.nth(simpleData.length - 1).getAttribute('d');
 
+    // 600 * 0.8 = 480 funnel width, 480 / 4 stages = 120 per segment, first x0 in RTL is 480 - 120 = 360.
     expect(firstSegmentPath).toContain('M360,');
+    // Last stage starts at x0 = 480 - (4 * 120) = 0 in RTL.
     expect(lastSegmentPath).toContain('M0,');
   });
 });

--- a/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.spec.ts
+++ b/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.spec.ts
@@ -151,11 +151,13 @@ test.describe('FunnelChart - Horizontal', () => {
     const segments = element.locator('.funnel-segment');
     const firstSegmentPath = await segments.nth(0).getAttribute('d');
     const lastSegmentPath = await segments.nth(simpleData.length - 1).getAttribute('d');
+    const funnelWidth = 600 * 0.8;
+    const segmentWidth = funnelWidth / simpleData.length;
+    const expectedFirstX = funnelWidth - segmentWidth;
+    const expectedLastX = 0;
 
-    // 600 * 0.8 = 480 funnel width, 480 / 4 stages = 120 per segment, first x0 in RTL is 480 - 120 = 360.
-    expect(firstSegmentPath).toContain('M360,');
-    // Last stage starts at x0 = 480 - (4 * 120) = 0 in RTL.
-    expect(lastSegmentPath).toContain('M0,');
+    expect(firstSegmentPath).toContain(`M${expectedFirstX},`);
+    expect(lastSegmentPath).toContain(`M${expectedLastX},`);
   });
 });
 

--- a/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.stories.ts
+++ b/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.stories.ts
@@ -1,0 +1,230 @@
+import { html } from '@microsoft/fast-element';
+import { FieldDefinition, FluentDesignSystem, SwitchDefinition } from '@fluentui/web-components';
+import type { Meta, Story, StoryArgs } from '../helpers.stories.js';
+import { renderComponent } from '../helpers.stories.js';
+import { FunnelChart as FluentFunnelChart } from './funnel-chart.js';
+import type { FunnelDataPoint } from './funnel-chart.options.js';
+
+type FluentSwitchElement = HTMLElement & { checked: boolean };
+
+const ensureDefinition = (tagName: string, define: () => void) => {
+  if (!customElements.get(tagName)) {
+    define();
+  }
+};
+
+ensureDefinition('fluent-field', () => FieldDefinition.define(FluentDesignSystem.registry));
+ensureDefinition('fluent-switch', () => SwitchDefinition.define(FluentDesignSystem.registry));
+
+const controlsRowStyle = 'display:flex;flex-wrap:wrap;gap:16px 24px;align-items:end;';
+const toggleFieldStyle = 'min-width:220px;';
+
+const createSwitchField = (
+  labelText: string,
+  id: string,
+  checked: boolean,
+  onChange: (nextChecked: boolean) => void,
+) => {
+  const field = document.createElement('fluent-field');
+  field.setAttribute('label-position', 'after');
+  field.setAttribute('style', toggleFieldStyle);
+
+  const label = document.createElement('label');
+  label.slot = 'label';
+  label.htmlFor = id;
+  label.textContent = labelText;
+  field.appendChild(label);
+
+  const control = document.createElement('fluent-switch') as FluentSwitchElement;
+  control.slot = 'input';
+  control.id = id;
+  control.checked = checked;
+  control.toggleAttribute('checked', checked);
+  control.addEventListener('change', () => onChange(control.checked));
+  field.appendChild(control);
+
+  return {
+    element: field,
+    setValue: (nextChecked: boolean) => {
+      control.checked = nextChecked;
+      control.toggleAttribute('checked', nextChecked);
+    },
+  };
+};
+
+// ── Sample data ──────────────────────────────────────────────────────────────
+
+const simpleData: FunnelDataPoint[] = [
+  { stage: 'Impressions', value: 8000, color: '#637cef' },
+  { stage: 'Clicks', value: 4000, color: '#e3008c' },
+  { stage: 'Leads', value: 1500, color: '#2aa0a4' },
+  { stage: 'Conversions', value: 600, color: '#9373c0' },
+];
+
+const stackedData: FunnelDataPoint[] = [
+  {
+    stage: 'Awareness',
+    subValues: [
+      { category: 'Organic', value: 5000, color: '#637cef' },
+      { category: 'Paid', value: 3000, color: '#e3008c' },
+    ],
+  },
+  {
+    stage: 'Interest',
+    subValues: [
+      { category: 'Organic', value: 3000, color: '#637cef' },
+      { category: 'Paid', value: 2000, color: '#e3008c' },
+    ],
+  },
+  {
+    stage: 'Decision',
+    subValues: [
+      { category: 'Organic', value: 1200, color: '#637cef' },
+      { category: 'Paid', value: 800, color: '#e3008c' },
+    ],
+  },
+  {
+    stage: 'Purchase',
+    subValues: [
+      { category: 'Organic', value: 500, color: '#637cef' },
+      { category: 'Paid', value: 300, color: '#e3008c' },
+    ],
+  },
+];
+
+// ── Stories ──────────────────────────────────────────────────────────────────
+
+export default {
+  title: 'Components/FunnelChart',
+} as Meta<FluentFunnelChart>;
+
+export const Basic: Story<FluentFunnelChart> = renderComponent(html<StoryArgs<FluentFunnelChart>>`
+  <fluent-funnel-chart
+    chart-title="Funnel chart basic example"
+    data="${JSON.stringify(simpleData)}"
+    width="350"
+    height="400"
+  ></fluent-funnel-chart>
+`);
+
+export const Horizontal: Story<FluentFunnelChart> = renderComponent(html<StoryArgs<FluentFunnelChart>>`
+  <fluent-funnel-chart
+    chart-title="Horizontal funnel chart"
+    data="${JSON.stringify(simpleData)}"
+    orientation="horizontal"
+    width="600"
+    height="300"
+  ></fluent-funnel-chart>
+`);
+
+export const Stacked: Story<FluentFunnelChart> = renderComponent(html<StoryArgs<FluentFunnelChart>>`
+  <fluent-funnel-chart
+    chart-title="Stacked funnel chart"
+    data="${JSON.stringify(stackedData)}"
+    width="350"
+    height="400"
+  ></fluent-funnel-chart>
+`);
+
+export const StackedHorizontal: Story<FluentFunnelChart> = renderComponent(html<StoryArgs<FluentFunnelChart>>`
+  <fluent-funnel-chart
+    chart-title="Stacked horizontal funnel chart"
+    data="${JSON.stringify(stackedData)}"
+    orientation="horizontal"
+    width="600"
+    height="300"
+  ></fluent-funnel-chart>
+`);
+
+export const HideLegends: Story<FluentFunnelChart> = renderComponent(html<StoryArgs<FluentFunnelChart>>`
+  <fluent-funnel-chart
+    chart-title="Funnel chart – hide legends"
+    data="${JSON.stringify(simpleData)}"
+    width="350"
+    height="400"
+    hide-legends
+  ></fluent-funnel-chart>
+`);
+
+export const HideTooltip: Story<FluentFunnelChart> = () => {
+  const container = document.createElement('div');
+  const controls = document.createElement('div');
+  controls.setAttribute('style', controlsRowStyle);
+  container.appendChild(controls);
+
+  let hideTooltip = true;
+
+  const chart = document.createElement('fluent-funnel-chart') as FluentFunnelChart;
+  chart.setAttribute('chart-title', 'Funnel chart – hide tooltip');
+  chart.setAttribute('data', JSON.stringify(simpleData));
+  chart.setAttribute('width', '350');
+  chart.setAttribute('height', '400');
+  chart.setAttribute('style', 'margin-top:20px;');
+  chart.toggleAttribute('hide-tooltip', hideTooltip);
+  container.appendChild(chart);
+
+  const hideTooltipControl = createSwitchField('Hide tooltip', 'funnel-hide-tooltip', hideTooltip, nextChecked => {
+    hideTooltip = nextChecked;
+    hideTooltipControl.setValue(nextChecked);
+    chart.hideTooltip = nextChecked;
+    chart.toggleAttribute('hide-tooltip', nextChecked);
+  });
+  controls.appendChild(hideTooltipControl.element);
+
+  return container;
+};
+
+export const MultipleLegendSelection: Story<FluentFunnelChart> = () => {
+  const container = document.createElement('div');
+  const controls = document.createElement('div');
+  controls.setAttribute('style', controlsRowStyle);
+  container.appendChild(controls);
+
+  let allowMultiple = true;
+
+  const chart = document.createElement('fluent-funnel-chart') as FluentFunnelChart;
+  chart.setAttribute('chart-title', 'Funnel chart – multiple legend selection');
+  chart.setAttribute('data', JSON.stringify(simpleData));
+  chart.setAttribute('width', '350');
+  chart.setAttribute('height', '400');
+  chart.setAttribute('style', 'margin-top:20px;');
+  chart.allowMultipleLegendSelection = allowMultiple;
+  chart.toggleAttribute('allow-multiple-legend-selection', allowMultiple);
+  container.appendChild(chart);
+
+  const multipleControl = createSwitchField(
+    'Allow multiple legend selection',
+    'funnel-multiple-legend',
+    allowMultiple,
+    nextChecked => {
+      allowMultiple = nextChecked;
+      multipleControl.setValue(nextChecked);
+      chart.allowMultipleLegendSelection = nextChecked;
+      chart.toggleAttribute('allow-multiple-legend-selection', nextChecked);
+    },
+  );
+  controls.appendChild(multipleControl.element);
+
+  return container;
+};
+
+export const RTL: Story<FluentFunnelChart> = renderComponent(html<StoryArgs<FluentFunnelChart>>`
+  <div dir="rtl">
+    <fluent-funnel-chart
+      chart-title="Funnel chart RTL example"
+      data="${JSON.stringify(simpleData)}"
+      width="350"
+      height="400"
+    ></fluent-funnel-chart>
+  </div>
+`);
+
+export const Culture: Story<FluentFunnelChart> = renderComponent(html<StoryArgs<FluentFunnelChart>>`
+  <fluent-funnel-chart
+    chart-title="Funnel chart culture example (de-DE)"
+    data="${JSON.stringify(simpleData)}"
+    width="350"
+    height="400"
+    culture="de-DE"
+  ></fluent-funnel-chart>
+`);

--- a/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.styles.ts
+++ b/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.styles.ts
@@ -1,0 +1,119 @@
+import { css } from '@microsoft/fast-element';
+import {
+  borderRadiusMedium,
+  colorNeutralBackground1,
+  colorNeutralForeground1,
+  colorNeutralShadowAmbient,
+  colorNeutralShadowKey,
+  colorStrokeFocus1,
+  colorStrokeFocus2,
+  colorTransparentStroke,
+  display,
+  spacingHorizontalL,
+  spacingHorizontalS,
+  spacingVerticalMNudge,
+  spacingVerticalS,
+  strokeWidthThickest,
+  strokeWidthThin,
+  typographyBody1StrongStyles,
+  typographyCaption1Styles,
+  typographyTitle2Styles,
+} from '@fluentui/web-components';
+import { tooltipBaseStyles } from '../utils/tooltip.styles.js';
+
+/**
+ * Styles for the FunnelChart component.
+ *
+ * @public
+ */
+export const styles = css`
+  ${display('block')}
+
+  :host {
+    ${typographyBody1StrongStyles}
+    width: 100%;
+    height: 100%;
+    position: relative;
+  }
+
+  .chart-title {
+    ${typographyBody1StrongStyles}
+    color: ${colorNeutralForeground1};
+    margin-bottom: ${spacingVerticalS};
+  }
+
+  .chart {
+    box-sizing: content-box;
+    overflow: visible;
+    display: block;
+  }
+
+  .funnel-segment {
+    transition: opacity 0.1s ease;
+  }
+
+  .funnel-segment.inactive {
+    opacity: 0.1;
+  }
+
+  .funnel-segment:focus {
+    outline: none;
+    stroke-width: ${strokeWidthThin};
+    stroke: ${colorStrokeFocus1};
+  }
+
+  .funnel-segment:focus-visible {
+    stroke-width: ${strokeWidthThickest};
+    stroke: ${colorStrokeFocus2};
+  }
+
+  .funnel-segment-text {
+    font-size: 12px;
+    pointer-events: none;
+    user-select: none;
+  }
+
+  .funnel-segment-text.inactive {
+    opacity: 0.1;
+  }
+
+  ${tooltipBaseStyles}
+
+  .tooltip {
+    z-index: 1;
+    background-blend-mode: normal, luminosity;
+    border-radius: ${borderRadiusMedium};
+    border: 1px solid ${colorTransparentStroke};
+    filter: drop-shadow(0 0 2px ${colorNeutralShadowAmbient}) drop-shadow(0 8px 16px ${colorNeutralShadowKey});
+  }
+
+  .tooltip-inner {
+    padding-inline-start: ${spacingHorizontalS};
+    color: ${colorNeutralForeground1};
+    border-inline-start: 4px solid;
+  }
+
+  .tooltip-legend-text {
+    ${typographyCaption1Styles}
+  }
+
+  .tooltip-value {
+    ${typographyTitle2Styles}
+  }
+
+  @media (forced-colors: active) {
+    .funnel-segment-text {
+      fill: CanvasText;
+    }
+
+    .tooltip-body {
+      forced-color-adjust: none;
+    }
+
+    .tooltip-legend-text,
+    .tooltip-content-y {
+      forced-color-adjust: auto;
+      color: CanvasText;
+    }
+  }
+`;

--- a/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.template.ts
+++ b/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.template.ts
@@ -1,0 +1,44 @@
+import { ElementViewTemplate, html, ref, when } from '@microsoft/fast-element';
+import type { FunnelChart } from './funnel-chart.js';
+import { chartTooltipTemplate } from '../utils/chart-tooltip.template.js';
+
+/**
+ * Generates a template for the FunnelChart component.
+ *
+ * @public
+ */
+export function funnelChartTemplate<T extends FunnelChart>(): ElementViewTemplate<T> {
+  return html<T>`
+    <template>
+      ${when(x => !!x.chartTitle, html<T>`<div class="chart-title">${x => x.chartTitle}</div>`)}
+      <div ${ref('chartContainer')}>
+        <svg
+          ${ref('svgElement')}
+          class="chart"
+          width="${x => x.width}"
+          height="${x => x.height}"
+          role="region"
+          aria-label="${x => x.chartTitle}"
+        >
+          <g ${ref('group')}></g>
+        </svg>
+      </div>
+      <fluent-chart-legend
+        :items="${x => x.legends}"
+        label="${x => x.legendListLabel}"
+        ?hidden="${x => x.hideLegends}"
+        @legend-click="${(x, c) => x.handleLegendClick((c.event as CustomEvent<string>).detail)}"
+        @legend-mouseover="${(x, c) => x.handleLegendMouseoverAndFocus((c.event as CustomEvent<string>).detail)}"
+        @legend-mouseout="${x => x.handleLegendMouseoutAndBlur()}"
+        @legend-focus="${(x, c) => x.handleLegendMouseoverAndFocus((c.event as CustomEvent<string>).detail)}"
+        @legend-blur="${x => x.handleLegendMouseoutAndBlur()}"
+      ></fluent-chart-legend>
+      ${chartTooltipTemplate<T>()}
+    </template>
+  `;
+}
+
+/**
+ * @internal
+ */
+export const template: ElementViewTemplate<FunnelChart> = funnelChartTemplate();

--- a/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.ts
+++ b/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.ts
@@ -175,7 +175,10 @@ export class FunnelChart extends ChartBase {
     if (simpleData.length === 0) {
       return;
     }
-    const maxValue = Math.max(1, ...simpleData.map(point => point.value));
+    const maxValue = Math.max(...simpleData.map(point => point.value));
+    if (maxValue <= 0) {
+      return;
+    }
     simpleData.forEach((d, i) => {
       const geom =
         this.orientation === 'vertical'

--- a/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.ts
+++ b/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.ts
@@ -15,6 +15,15 @@ import {
   isStackedFunnelData,
 } from './funnel-geometry.js';
 
+const orientationConverter = {
+  fromView(value: string | null): 'vertical' | 'horizontal' {
+    return value === 'horizontal' ? 'horizontal' : 'vertical';
+  },
+  toView(value: 'vertical' | 'horizontal'): string {
+    return value;
+  },
+};
+
 /**
  * A Funnel Chart HTML Element.
  * Supports vertical and horizontal orientation, and stacked sub-values.
@@ -31,7 +40,7 @@ export class FunnelChart extends ChartBase {
   @attr({ converter: jsonConverter })
   public data!: FunnelDataPoint[];
 
-  @attr
+  @attr({ converter: orientationConverter })
   public orientation: 'vertical' | 'horizontal' = 'vertical';
 
   public svgElement!: SVGSVGElement;
@@ -85,11 +94,7 @@ export class FunnelChart extends ChartBase {
     this._requestRender();
   }
 
-  protected orientationChanged(_oldValue: string, newValue: string) {
-    if (newValue !== 'horizontal' && newValue !== 'vertical') {
-      this.orientation = 'vertical';
-      return;
-    }
+  protected orientationChanged(_oldValue: string, _newValue: string) {
     this._requestRender();
   }
 
@@ -167,6 +172,9 @@ export class FunnelChart extends ChartBase {
 
   private _renderSimpleFunnel(data: FunnelDataPoint[], funnelWidth: number, funnelHeight: number) {
     const simpleData = data.filter(isSimpleFunnelDataPoint);
+    if (simpleData.length === 0) {
+      return;
+    }
     const maxValue = Math.max(1, ...simpleData.map(point => point.value));
     simpleData.forEach((d, i) => {
       const geom =

--- a/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.ts
+++ b/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.ts
@@ -1,0 +1,349 @@
+import { attr, nullableNumberConverter } from '@microsoft/fast-element';
+import { ChartBase } from '../utils/chart-base.js';
+import { getColorFromToken, getNextColor, jsonConverter, SVG_NAMESPACE_URI } from '../utils/chart-helpers.js';
+import type { FunnelDataPoint, FunnelOrientation, FunnelSubValue } from './funnel-chart.options.js';
+import type { Legend } from '../utils/chart.options.js';
+import {
+  buildStackedGeometryParams,
+  getContrastTextColor,
+  getHorizontalFunnelSegmentGeometry,
+  getSegmentTextProps,
+  getStackedHorizontalFunnelSegmentGeometry,
+  getStackedVerticalFunnelSegmentGeometry,
+  getVerticalFunnelSegmentGeometry,
+  isStackedFunnelData,
+} from './funnelGeometry.js';
+
+/**
+ * A Funnel Chart HTML Element.
+ * Supports vertical and horizontal orientation, and stacked sub-values.
+ *
+ * @public
+ */
+export class FunnelChart extends ChartBase {
+  @attr({ converter: nullableNumberConverter })
+  public width: number = 350;
+
+  @attr({ converter: nullableNumberConverter })
+  public height: number = 500;
+
+  @attr({ converter: jsonConverter })
+  public data!: FunnelDataPoint[];
+
+  @attr
+  public orientation: FunnelOrientation = 'vertical';
+
+  public svgElement!: SVGSVGElement;
+  public group!: SVGGElement;
+
+  private _segments: SVGPathElement[] = [];
+  private _segmentTexts: SVGTextElement[] = [];
+
+  private readonly _handleMouseLeave = () => {
+    this._clearTooltip();
+  };
+
+  connectedCallback() {
+    const self = this as Record<string, unknown>;
+    const attrFields = ['width', 'height', 'data', 'orientation'] as const;
+    const saved: Partial<Record<(typeof attrFields)[number], unknown>> = {};
+
+    for (const field of attrFields) {
+      saved[field] = self[field];
+      delete self[field];
+    }
+
+    super.connectedCallback();
+
+    for (const field of attrFields) {
+      if (self[field] === undefined && saved[field] !== undefined) {
+        self[field] = saved[field];
+      }
+    }
+
+    this.addEventListener('mouseleave', this._handleMouseLeave);
+    this._requestRender();
+  }
+
+  public disconnectedCallback() {
+    this.removeEventListener('mouseleave', this._handleMouseLeave);
+    super.disconnectedCallback();
+  }
+
+  protected dataChanged(_oldValue: FunnelDataPoint[], newValue: FunnelDataPoint[]) {
+    if (newValue) {
+      this._requestRender();
+    }
+  }
+
+  protected widthChanged() {
+    this._requestRender();
+  }
+
+  protected heightChanged() {
+    this._requestRender();
+  }
+
+  protected orientationChanged() {
+    this._requestRender();
+  }
+
+  protected _getHostAriaLabel(): string {
+    return this.chartTitle || `Funnel chart with ${this.data?.length ?? 0} stages.`;
+  }
+
+  protected _performRender(): void {
+    if (!this.$fastController.isConnected || !this.data || !this.group) {
+      return;
+    }
+    this._clearChart();
+    this._initializeAndRender();
+  }
+
+  private _clearChart() {
+    while (this.group.firstChild) {
+      this.group.removeChild(this.group.firstChild);
+    }
+    this._segments = [];
+    this._segmentTexts = [];
+  }
+
+  private _initializeAndRender() {
+    const data = this._resolveColors();
+    this.legends = this._buildLegends(data);
+    this.elementInternals.ariaLabel = this._getHostAriaLabel();
+
+    if (this.svgElement) {
+      this.svgElement.setAttribute('width', String(this.width));
+      this.svgElement.setAttribute('height', String(this.height));
+    }
+
+    const funnelWidth = this.width * 0.8;
+    const funnelHeight = this.height * 0.8;
+    const funnelOffsetX = (this.width - funnelWidth) / 2;
+    const funnelOffsetY = (this.height - funnelHeight) / 2;
+
+    this.group.setAttribute('transform', `translate(${funnelOffsetX}, ${funnelOffsetY})`);
+
+    if (isStackedFunnelData(data)) {
+      this._renderStackedFunnel(data, funnelWidth, funnelHeight);
+    } else {
+      this._renderSimpleFunnel(data, funnelWidth, funnelHeight);
+    }
+
+    this._applyActiveLegendState();
+    this._applyLegendButtonState();
+  }
+
+  private _resolveColors(): FunnelDataPoint[] {
+    return this.data.map((d, i) => {
+      if (d.subValues) {
+        return d;
+      }
+      const color = d.color ? getColorFromToken(d.color) : getNextColor(i);
+      return { ...d, color };
+    });
+  }
+
+  private _buildLegends(data: FunnelDataPoint[]): Legend[] {
+    if (isStackedFunnelData(data)) {
+      const seen = new Map<string, string>();
+      data.forEach(stage => {
+        (stage.subValues ?? []).forEach(sv => {
+          if (!seen.has(sv.category)) {
+            seen.set(sv.category, sv.color);
+          }
+        });
+      });
+      return Array.from(seen.entries()).map(([category, color]) => ({ legend: category, color }));
+    }
+    return data.map(d => ({ legend: d.stage, color: d.color! }));
+  }
+
+  private _renderSimpleFunnel(data: FunnelDataPoint[], funnelWidth: number, funnelHeight: number) {
+    data.forEach((d, i) => {
+      const geom =
+        this.orientation === 'vertical'
+          ? getVerticalFunnelSegmentGeometry({ d, i, data, funnelWidth, funnelHeight, isRTL: this._isRTL })
+          : getHorizontalFunnelSegmentGeometry({ d, i, data, funnelWidth, funnelHeight, isRTL: this._isRTL });
+
+      const textProps = getSegmentTextProps({
+        availableWidth: geom.availableWidth,
+        textX: geom.textX,
+        textY: geom.textY,
+        value: d.value!,
+      });
+
+      this._createSegment({
+        key: `${i}`,
+        pathD: geom.pathD,
+        fill: d.color!,
+        ariaLabel: `${d.stage}, ${d.value}.`,
+        legendKey: d.stage,
+        textProps,
+        onHover: (event: MouseEvent) => this._showTooltip(d.stage, String(d.value!), d.color!, event),
+        onFocus: (path: SVGPathElement) => this._showTooltipForElement(d.stage, String(d.value!), d.color!, path),
+      });
+    });
+  }
+
+  private _renderStackedFunnel(data: FunnelDataPoint[], funnelWidth: number, funnelHeight: number) {
+    const { stages, totals, maxTotal } = buildStackedGeometryParams(data);
+
+    data.forEach((stage, i) => {
+      (stage.subValues ?? []).forEach((sv: FunnelSubValue, k) => {
+        const geom =
+          this.orientation === 'vertical'
+            ? getStackedVerticalFunnelSegmentGeometry({ i, k, stages, totals, maxTotal, funnelWidth, funnelHeight })
+            : getStackedHorizontalFunnelSegmentGeometry({ i, k, stages, totals, maxTotal, funnelWidth, funnelHeight });
+
+        const textProps = getSegmentTextProps({
+          availableWidth: geom.availableWidth,
+          textX: geom.textX,
+          textY: geom.textY,
+          value: sv.value,
+        });
+
+        this._createSegment({
+          key: `${i}-${k}`,
+          pathD: geom.pathD,
+          fill: sv.color,
+          ariaLabel: `${stage.stage}, ${sv.category}, ${sv.value}.`,
+          legendKey: sv.category,
+          textProps,
+          onHover: (event: MouseEvent) => this._showTooltip(sv.category, String(sv.value), sv.color, event),
+          onFocus: (path: SVGPathElement) =>
+            this._showTooltipForElement(sv.category, String(sv.value), sv.color, path),
+        });
+      });
+    });
+  }
+
+  private _createSegment({
+    key,
+    pathD,
+    fill,
+    ariaLabel,
+    legendKey,
+    textProps,
+    onHover,
+    onFocus,
+  }: {
+    key: string;
+    pathD: string;
+    fill: string;
+    ariaLabel: string;
+    legendKey: string;
+    textProps: { show: boolean; x: number; y: number; value: number };
+    onHover: (event: MouseEvent) => void;
+    onFocus: (path: SVGPathElement) => void;
+  }) {
+    const segGroup = document.createElementNS(SVG_NAMESPACE_URI, 'g');
+    this.group.appendChild(segGroup);
+
+    const path = document.createElementNS(SVG_NAMESPACE_URI, 'path');
+    segGroup.appendChild(path);
+    path.classList.add('funnel-segment');
+    path.setAttribute('d', pathD);
+    path.setAttribute('fill', fill);
+    path.setAttribute('data-id', legendKey);
+    path.setAttribute('tabindex', '0');
+    path.setAttribute('role', 'img');
+    path.setAttribute('aria-label', ariaLabel);
+    this._segments.push(path);
+
+    path.addEventListener('mouseover', event => {
+      if (!this._shouldShowTooltip(legendKey)) {
+        return;
+      }
+      onHover(event as MouseEvent);
+    });
+
+    path.addEventListener('mousemove', event => {
+      if (!this._shouldShowTooltip(legendKey)) {
+        return;
+      }
+      onHover(event as MouseEvent);
+    });
+
+    path.addEventListener('focus', () => {
+      if (!this._shouldShowTooltip(legendKey)) {
+        return;
+      }
+      onFocus(path);
+    });
+
+    path.addEventListener('blur', () => {
+      this._clearTooltip();
+    });
+
+    path.addEventListener('mouseout', () => {
+      this._clearTooltip();
+    });
+
+    if (textProps.show) {
+      const textEl = document.createElementNS(SVG_NAMESPACE_URI, 'text');
+      segGroup.appendChild(textEl);
+      textEl.classList.add('funnel-segment-text');
+      textEl.setAttribute('x', String(textProps.x));
+      textEl.setAttribute('y', String(textProps.y));
+      textEl.setAttribute('text-anchor', 'middle');
+      textEl.setAttribute('dominant-baseline', 'middle');
+      textEl.setAttribute('fill', getContrastTextColor(fill));
+      textEl.setAttribute('pointer-events', 'none');
+      textEl.setAttribute('data-id', legendKey);
+      textEl.textContent = textProps.value.toLocaleString(this.culture ?? undefined);
+      this._segmentTexts.push(textEl);
+    }
+  }
+
+  private _showTooltip(legend: string, yValue: string, color: string, event: MouseEvent) {
+    const bounds = this.getBoundingClientRect();
+    this.tooltipProps = {
+      isVisible: true,
+      legend,
+      yValue,
+      color,
+      xPos: this._isRTL ? bounds.right - event.clientX : event.clientX - bounds.left,
+      yPos: event.clientY - bounds.top - 85,
+    };
+  }
+
+  private _showTooltipForElement(legend: string, yValue: string, color: string, el: SVGPathElement) {
+    const rootBounds = this.getBoundingClientRect();
+    const elBounds = el.getBoundingClientRect();
+    this.tooltipProps = {
+      isVisible: true,
+      legend,
+      yValue,
+      color,
+      xPos: this._isRTL
+        ? rootBounds.right - elBounds.left - elBounds.width / 2
+        : elBounds.left + elBounds.width / 2 - rootBounds.left,
+      yPos: elBounds.top - rootBounds.top - 85,
+    };
+  }
+
+  protected _applyActiveLegendState() {
+    const highlighted = this._getHighlightedLegends();
+
+    if (highlighted.length === 0) {
+      this._segments.forEach(seg => {
+        seg.classList.remove('inactive');
+        seg.setAttribute('tabindex', '0');
+      });
+      this._segmentTexts.forEach(t => t.classList.remove('inactive'));
+    } else {
+      this._segments.forEach(seg => {
+        const id = seg.getAttribute('data-id');
+        const isActive = id !== null && highlighted.includes(id);
+        seg.classList.toggle('inactive', !isActive);
+        seg.setAttribute('tabindex', isActive ? '0' : '-1');
+      });
+      this._segmentTexts.forEach(t => {
+        const id = t.getAttribute('data-id');
+        t.classList.toggle('inactive', id === null || !highlighted.includes(id));
+      });
+    }
+  }
+}

--- a/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.ts
+++ b/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.ts
@@ -94,7 +94,7 @@ export class FunnelChart extends ChartBase {
     this._requestRender();
   }
 
-  protected orientationChanged(_oldValue: string, _newValue: string) {
+  protected orientationChanged() {
     this._requestRender();
   }
 

--- a/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.ts
+++ b/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.ts
@@ -1,8 +1,8 @@
 import { attr, nullableNumberConverter } from '@microsoft/fast-element';
 import { ChartBase } from '../utils/chart-base.js';
 import { getColorFromToken, getNextColor, jsonConverter, SVG_NAMESPACE_URI } from '../utils/chart-helpers.js';
-import type { FunnelDataPoint, FunnelOrientation, FunnelSubValue } from './funnel-chart.options.js';
 import type { Legend } from '../utils/chart.options.js';
+import type { FunnelDataPoint, FunnelOrientation, FunnelSubValue } from './funnel-chart.options.js';
 import {
   buildStackedGeometryParams,
   getContrastTextColor,
@@ -11,8 +11,18 @@ import {
   getStackedHorizontalFunnelSegmentGeometry,
   getStackedVerticalFunnelSegmentGeometry,
   getVerticalFunnelSegmentGeometry,
+  isSimpleFunnelDataPoint,
   isStackedFunnelData,
-} from './funnelGeometry.js';
+} from './funnel-geometry.js';
+
+const orientationConverter = {
+  fromView(value: string | null): FunnelOrientation {
+    return value === 'horizontal' ? 'horizontal' : 'vertical';
+  },
+  toView(value: FunnelOrientation): string {
+    return value;
+  },
+};
 
 /**
  * A Funnel Chart HTML Element.
@@ -30,7 +40,7 @@ export class FunnelChart extends ChartBase {
   @attr({ converter: jsonConverter })
   public data!: FunnelDataPoint[];
 
-  @attr
+  @attr({ converter: orientationConverter })
   public orientation: FunnelOrientation = 'vertical';
 
   public svgElement!: SVGSVGElement;
@@ -84,7 +94,11 @@ export class FunnelChart extends ChartBase {
     this._requestRender();
   }
 
-  protected orientationChanged() {
+  protected orientationChanged(_oldValue: FunnelOrientation, newValue: FunnelOrientation) {
+    if (newValue !== 'horizontal' && newValue !== 'vertical') {
+      this.orientation = 'vertical';
+      return;
+    }
     this._requestRender();
   }
 
@@ -157,21 +171,29 @@ export class FunnelChart extends ChartBase {
       });
       return Array.from(seen.entries()).map(([category, color]) => ({ legend: category, color }));
     }
-    return data.map(d => ({ legend: d.stage, color: d.color! }));
+    return data.filter(isSimpleFunnelDataPoint).map(d => ({ legend: d.stage, color: d.color! }));
   }
 
   private _renderSimpleFunnel(data: FunnelDataPoint[], funnelWidth: number, funnelHeight: number) {
-    data.forEach((d, i) => {
+    const simpleData = data.filter(isSimpleFunnelDataPoint);
+    simpleData.forEach((d, i) => {
       const geom =
         this.orientation === 'vertical'
-          ? getVerticalFunnelSegmentGeometry({ d, i, data, funnelWidth, funnelHeight, isRTL: this._isRTL })
-          : getHorizontalFunnelSegmentGeometry({ d, i, data, funnelWidth, funnelHeight, isRTL: this._isRTL });
+          ? getVerticalFunnelSegmentGeometry({ d, i, data: simpleData, funnelWidth, funnelHeight, isRTL: this._isRTL })
+          : getHorizontalFunnelSegmentGeometry({
+              d,
+              i,
+              data: simpleData,
+              funnelWidth,
+              funnelHeight,
+              isRTL: this._isRTL,
+            });
 
       const textProps = getSegmentTextProps({
         availableWidth: geom.availableWidth,
         textX: geom.textX,
         textY: geom.textY,
-        value: d.value!,
+        value: d.value,
       });
 
       this._createSegment({
@@ -181,8 +203,8 @@ export class FunnelChart extends ChartBase {
         ariaLabel: `${d.stage}, ${d.value}.`,
         legendKey: d.stage,
         textProps,
-        onHover: (event: MouseEvent) => this._showTooltip(d.stage, String(d.value!), d.color!, event),
-        onFocus: (path: SVGPathElement) => this._showTooltipForElement(d.stage, String(d.value!), d.color!, path),
+        onHover: (event: MouseEvent) => this._showTooltip(d.stage, String(d.value), d.color!, event),
+        onFocus: (path: SVGPathElement) => this._showTooltipForElement(d.stage, String(d.value), d.color!, path),
       });
     });
   }
@@ -212,8 +234,7 @@ export class FunnelChart extends ChartBase {
           legendKey: sv.category,
           textProps,
           onHover: (event: MouseEvent) => this._showTooltip(sv.category, String(sv.value), sv.color, event),
-          onFocus: (path: SVGPathElement) =>
-            this._showTooltipForElement(sv.category, String(sv.value), sv.color, path),
+          onFocus: (path: SVGPathElement) => this._showTooltipForElement(sv.category, String(sv.value), sv.color, path),
         });
       });
     });

--- a/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.ts
+++ b/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.ts
@@ -2,7 +2,7 @@ import { attr, nullableNumberConverter } from '@microsoft/fast-element';
 import { ChartBase } from '../utils/chart-base.js';
 import { getColorFromToken, getNextColor, jsonConverter, SVG_NAMESPACE_URI } from '../utils/chart-helpers.js';
 import type { Legend } from '../utils/chart.options.js';
-import type { FunnelDataPoint, FunnelOrientation, FunnelSubValue } from './funnel-chart.options.js';
+import type { FunnelDataPoint, FunnelSubValue } from './funnel-chart.options.js';
 import {
   buildStackedGeometryParams,
   getContrastTextColor,
@@ -14,15 +14,6 @@ import {
   isSimpleFunnelDataPoint,
   isStackedFunnelData,
 } from './funnel-geometry.js';
-
-const orientationConverter = {
-  fromView(value: string | null): FunnelOrientation {
-    return value === 'horizontal' ? 'horizontal' : 'vertical';
-  },
-  toView(value: FunnelOrientation): string {
-    return value;
-  },
-};
 
 /**
  * A Funnel Chart HTML Element.
@@ -40,8 +31,8 @@ export class FunnelChart extends ChartBase {
   @attr({ converter: jsonConverter })
   public data!: FunnelDataPoint[];
 
-  @attr({ converter: orientationConverter })
-  public orientation: FunnelOrientation = 'vertical';
+  @attr
+  public orientation: 'vertical' | 'horizontal' = 'vertical';
 
   public svgElement!: SVGSVGElement;
   public group!: SVGGElement;
@@ -94,7 +85,7 @@ export class FunnelChart extends ChartBase {
     this._requestRender();
   }
 
-  protected orientationChanged(_oldValue: FunnelOrientation, newValue: FunnelOrientation) {
+  protected orientationChanged(_oldValue: string, newValue: string) {
     if (newValue !== 'horizontal' && newValue !== 'vertical') {
       this.orientation = 'vertical';
       return;
@@ -176,14 +167,24 @@ export class FunnelChart extends ChartBase {
 
   private _renderSimpleFunnel(data: FunnelDataPoint[], funnelWidth: number, funnelHeight: number) {
     const simpleData = data.filter(isSimpleFunnelDataPoint);
+    const maxValue = Math.max(1, ...simpleData.map(point => point.value));
     simpleData.forEach((d, i) => {
       const geom =
         this.orientation === 'vertical'
-          ? getVerticalFunnelSegmentGeometry({ d, i, data: simpleData, funnelWidth, funnelHeight, isRTL: this._isRTL })
+          ? getVerticalFunnelSegmentGeometry({
+              d,
+              i,
+              data: simpleData,
+              maxValue,
+              funnelWidth,
+              funnelHeight,
+              isRTL: this._isRTL,
+            })
           : getHorizontalFunnelSegmentGeometry({
               d,
               i,
               data: simpleData,
+              maxValue,
               funnelWidth,
               funnelHeight,
               isRTL: this._isRTL,

--- a/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.ts
+++ b/packages/charts/chart-web-components/src/funnel-chart/funnel-chart.ts
@@ -15,6 +15,9 @@ import {
   isStackedFunnelData,
 } from './funnel-geometry.js';
 
+/**
+ * Normalizes orientation attribute values and defaults invalid values to `vertical`.
+ */
 const orientationConverter = {
   fromView(value: string | null): 'vertical' | 'horizontal' {
     return value === 'horizontal' ? 'horizontal' : 'vertical';

--- a/packages/charts/chart-web-components/src/funnel-chart/funnel-geometry.ts
+++ b/packages/charts/chart-web-components/src/funnel-chart/funnel-geometry.ts
@@ -97,7 +97,7 @@ export function getHorizontalFunnelSegmentGeometry({
   const nextYOffset = (funnelHeight - rightHeight) / 2;
   const x0 = isRTL ? funnelWidth - (i + 1) * segmentWidth : i * segmentWidth;
   const x1 = isRTL ? funnelWidth - i * segmentWidth : (i + 1) * segmentWidth;
-  const segmentSpan = Math.abs(x1 - x0);
+  const segmentPixelWidth = Math.abs(x1 - x0);
 
   const isLastSegment = i === data.length - 1;
   let textX: number;
@@ -105,19 +105,19 @@ export function getHorizontalFunnelSegmentGeometry({
   let availableWidth = segmentWidth * 0.8;
 
   if (isLastSegment) {
-    textX = x0 + segmentSpan * 0.25;
+    textX = x0 + segmentPixelWidth * 0.25;
     textY = funnelHeight / 2;
-    const segmentArea = (leftHeight * segmentSpan) / 2;
+    const segmentArea = (leftHeight * segmentPixelWidth) / 2;
     if (leftHeight < 40 || segmentArea < 800) {
       availableWidth = 0;
     } else {
-      availableWidth = segmentSpan * 0.75 * 0.6;
+      availableWidth = segmentPixelWidth * 0.75 * 0.6;
     }
   } else {
     textX = (x0 + x1) / 2;
     textY = funnelHeight / 2;
     const minHeight = Math.min(leftHeight, rightHeight);
-    availableWidth = minHeight > 20 ? segmentSpan * 0.8 : 0;
+    availableWidth = minHeight > 20 ? segmentPixelWidth * 0.8 : 0;
   }
 
   const pathD = `M${x0},${yOffset}

--- a/packages/charts/chart-web-components/src/funnel-chart/funnel-geometry.ts
+++ b/packages/charts/chart-web-components/src/funnel-chart/funnel-geometry.ts
@@ -97,6 +97,7 @@ export function getHorizontalFunnelSegmentGeometry({
   const nextYOffset = (funnelHeight - rightHeight) / 2;
   const x0 = isRTL ? funnelWidth - (i + 1) * segmentWidth : i * segmentWidth;
   const x1 = isRTL ? funnelWidth - i * segmentWidth : (i + 1) * segmentWidth;
+  const segmentSpan = Math.abs(x1 - x0);
 
   const isLastSegment = i === data.length - 1;
   let textX: number;
@@ -104,19 +105,19 @@ export function getHorizontalFunnelSegmentGeometry({
   let availableWidth = segmentWidth * 0.8;
 
   if (isLastSegment) {
-    textX = x0 + (x1 - x0) * 0.25;
+    textX = isRTL ? x0 - segmentSpan * 0.25 : x0 + segmentSpan * 0.25;
     textY = funnelHeight / 2;
-    const segmentArea = (leftHeight * segmentWidth) / 2;
+    const segmentArea = (leftHeight * segmentSpan) / 2;
     if (leftHeight < 40 || segmentArea < 800) {
       availableWidth = 0;
     } else {
-      availableWidth = (x1 - x0) * 0.75 * 0.6;
+      availableWidth = segmentSpan * 0.75 * 0.6;
     }
   } else {
     textX = (x0 + x1) / 2;
     textY = funnelHeight / 2;
     const minHeight = Math.min(leftHeight, rightHeight);
-    availableWidth = minHeight > 20 ? segmentWidth * 0.8 : 0;
+    availableWidth = minHeight > 20 ? segmentSpan * 0.8 : 0;
   }
 
   const pathD = `M${x0},${yOffset}

--- a/packages/charts/chart-web-components/src/funnel-chart/funnel-geometry.ts
+++ b/packages/charts/chart-web-components/src/funnel-chart/funnel-geometry.ts
@@ -5,7 +5,7 @@ export interface SimpleFunnelDataPoint extends FunnelDataPoint {
 }
 
 export function isSimpleFunnelDataPoint(dataPoint: FunnelDataPoint): dataPoint is SimpleFunnelDataPoint {
-  return Number.isFinite(dataPoint.value);
+  return typeof dataPoint.value === 'number' && Number.isFinite(dataPoint.value);
 }
 
 export interface FunnelSegmentGeometry {
@@ -24,6 +24,9 @@ interface SubValue {
 interface Stage {
   subValues: SubValue[];
 }
+
+const LAST_SEGMENT_TEXT_OFFSET_RATIO = 0.25;
+const LAST_SEGMENT_LABEL_WIDTH_RATIO = 0.75 * 0.6;
 
 /**
  * Gets vertical funnel segment geometry scaled by `maxValue`, the maximum stage value across all simple data points.
@@ -111,13 +114,13 @@ export function getHorizontalFunnelSegmentGeometry({
   let availableWidth = segmentWidth * 0.8;
 
   if (isLastSegment) {
-    textX = x0 + segmentPixelWidth * 0.25;
+    textX = x0 + segmentPixelWidth * LAST_SEGMENT_TEXT_OFFSET_RATIO;
     textY = funnelHeight / 2;
     const segmentArea = (leftHeight * segmentPixelWidth) / 2;
     if (leftHeight < 40 || segmentArea < 800) {
       availableWidth = 0;
     } else {
-      availableWidth = segmentPixelWidth * 0.75 * 0.6;
+      availableWidth = segmentPixelWidth * LAST_SEGMENT_LABEL_WIDTH_RATIO;
     }
   } else {
     textX = (x0 + x1) / 2;

--- a/packages/charts/chart-web-components/src/funnel-chart/funnel-geometry.ts
+++ b/packages/charts/chart-web-components/src/funnel-chart/funnel-geometry.ts
@@ -26,7 +26,8 @@ interface Stage {
 }
 
 const LAST_SEGMENT_TEXT_OFFSET_RATIO = 0.25;
-const LAST_SEGMENT_LABEL_WIDTH_RATIO = 0.75 * 0.6;
+// Width ratio for the label area in the tapered final segment (75% of segment width, then 60% padding factor).
+const LAST_SEGMENT_LABEL_WIDTH_RATIO = 0.45;
 
 /**
  * Gets vertical funnel segment geometry scaled by `maxValue`, the maximum stage value across all simple data points.
@@ -104,6 +105,7 @@ export function getHorizontalFunnelSegmentGeometry({
   const rightHeight = i < data.length - 1 ? heightScale(data[i + 1].value) : 0;
   const yOffset = (funnelHeight - leftHeight) / 2;
   const nextYOffset = (funnelHeight - rightHeight) / 2;
+  // Mirror segment x-coordinates in RTL so stages render from right to left.
   const x0 = isRTL ? funnelWidth - (i + 1) * segmentWidth : i * segmentWidth;
   const x1 = isRTL ? funnelWidth - i * segmentWidth : (i + 1) * segmentWidth;
   const segmentPixelWidth = Math.abs(x1 - x0);

--- a/packages/charts/chart-web-components/src/funnel-chart/funnel-geometry.ts
+++ b/packages/charts/chart-web-components/src/funnel-chart/funnel-geometry.ts
@@ -1,4 +1,12 @@
-import type { FunnelDataPoint, FunnelSubValue } from './funnel-chart.options.js';
+import type { FunnelDataPoint } from './funnel-chart.options.js';
+
+export interface SimpleFunnelDataPoint extends FunnelDataPoint {
+  value: number;
+}
+
+export function isSimpleFunnelDataPoint(dataPoint: FunnelDataPoint): dataPoint is SimpleFunnelDataPoint {
+  return Number.isFinite(dataPoint.value);
+}
 
 export interface FunnelSegmentGeometry {
   pathD: string;
@@ -25,17 +33,17 @@ export function getVerticalFunnelSegmentGeometry({
   funnelHeight,
   isRTL,
 }: {
-  d: FunnelDataPoint;
+  d: SimpleFunnelDataPoint;
   i: number;
-  data: FunnelDataPoint[];
+  data: SimpleFunnelDataPoint[];
   funnelWidth: number;
   funnelHeight: number;
   isRTL: boolean;
 }): FunnelSegmentGeometry {
   const segmentHeight = funnelHeight / data.length;
-  const widthScale = (value: number) => (value / Math.max(...data.map(dp => dp.value!))) * funnelWidth;
-  const topWidth = widthScale(d.value!);
-  const bottomWidth = i < data.length - 1 ? widthScale(data[i + 1].value!) : 0;
+  const widthScale = (value: number) => (value / Math.max(...data.map(dp => dp.value))) * funnelWidth;
+  const topWidth = widthScale(d.value);
+  const bottomWidth = i < data.length - 1 ? widthScale(data[i + 1].value) : 0;
   const xOffset = (funnelWidth - topWidth) / 2;
   const nextXOffset = (funnelWidth - bottomWidth) / 2;
   const xStart = isRTL ? funnelWidth - xOffset : xOffset;
@@ -70,21 +78,21 @@ export function getHorizontalFunnelSegmentGeometry({
   funnelHeight,
   isRTL,
 }: {
-  d: FunnelDataPoint;
+  d: SimpleFunnelDataPoint;
   i: number;
-  data: FunnelDataPoint[];
+  data: SimpleFunnelDataPoint[];
   funnelWidth: number;
   funnelHeight: number;
   isRTL: boolean;
 }): FunnelSegmentGeometry {
   const segmentWidth = funnelWidth / data.length;
-  const heightScale = (value: number) => (value / Math.max(...data.map(dp => dp.value!))) * funnelHeight;
-  const leftHeight = heightScale(d.value!);
-  const rightHeight = i < data.length - 1 ? heightScale(data[i + 1].value!) : 0;
+  const heightScale = (value: number) => (value / Math.max(...data.map(dp => dp.value))) * funnelHeight;
+  const leftHeight = heightScale(d.value);
+  const rightHeight = i < data.length - 1 ? heightScale(data[i + 1].value) : 0;
   const yOffset = (funnelHeight - leftHeight) / 2;
   const nextYOffset = (funnelHeight - rightHeight) / 2;
-  const x0 = i * segmentWidth;
-  const x1 = (i + 1) * segmentWidth;
+  const x0 = isRTL ? funnelWidth - (i + 1) * segmentWidth : i * segmentWidth;
+  const x1 = isRTL ? funnelWidth - i * segmentWidth : (i + 1) * segmentWidth;
 
   const isLastSegment = i === data.length - 1;
   let textX: number;

--- a/packages/charts/chart-web-components/src/funnel-chart/funnel-geometry.ts
+++ b/packages/charts/chart-web-components/src/funnel-chart/funnel-geometry.ts
@@ -105,7 +105,7 @@ export function getHorizontalFunnelSegmentGeometry({
   let availableWidth = segmentWidth * 0.8;
 
   if (isLastSegment) {
-    textX = isRTL ? x0 - segmentSpan * 0.25 : x0 + segmentSpan * 0.25;
+    textX = x0 + segmentSpan * 0.25;
     textY = funnelHeight / 2;
     const segmentArea = (leftHeight * segmentSpan) / 2;
     if (leftHeight < 40 || segmentArea < 800) {

--- a/packages/charts/chart-web-components/src/funnel-chart/funnel-geometry.ts
+++ b/packages/charts/chart-web-components/src/funnel-chart/funnel-geometry.ts
@@ -25,6 +25,9 @@ interface Stage {
   subValues: SubValue[];
 }
 
+/**
+ * Gets vertical funnel segment geometry scaled by `maxValue`, the maximum stage value across all simple data points.
+ */
 export function getVerticalFunnelSegmentGeometry({
   d,
   i,
@@ -72,6 +75,9 @@ export function getVerticalFunnelSegmentGeometry({
   return { pathD, textX, textY, availableWidth };
 }
 
+/**
+ * Gets horizontal funnel segment geometry scaled by `maxValue`, mirroring x coordinates when `isRTL` is true.
+ */
 export function getHorizontalFunnelSegmentGeometry({
   d,
   i,

--- a/packages/charts/chart-web-components/src/funnel-chart/funnel-geometry.ts
+++ b/packages/charts/chart-web-components/src/funnel-chart/funnel-geometry.ts
@@ -29,6 +29,7 @@ export function getVerticalFunnelSegmentGeometry({
   d,
   i,
   data,
+  maxValue,
   funnelWidth,
   funnelHeight,
   isRTL,
@@ -36,12 +37,13 @@ export function getVerticalFunnelSegmentGeometry({
   d: SimpleFunnelDataPoint;
   i: number;
   data: SimpleFunnelDataPoint[];
+  maxValue: number;
   funnelWidth: number;
   funnelHeight: number;
   isRTL: boolean;
 }): FunnelSegmentGeometry {
   const segmentHeight = funnelHeight / data.length;
-  const widthScale = (value: number) => (value / Math.max(...data.map(dp => dp.value))) * funnelWidth;
+  const widthScale = (value: number) => (value / maxValue) * funnelWidth;
   const topWidth = widthScale(d.value);
   const bottomWidth = i < data.length - 1 ? widthScale(data[i + 1].value) : 0;
   const xOffset = (funnelWidth - topWidth) / 2;
@@ -74,6 +76,7 @@ export function getHorizontalFunnelSegmentGeometry({
   d,
   i,
   data,
+  maxValue,
   funnelWidth,
   funnelHeight,
   isRTL,
@@ -81,12 +84,13 @@ export function getHorizontalFunnelSegmentGeometry({
   d: SimpleFunnelDataPoint;
   i: number;
   data: SimpleFunnelDataPoint[];
+  maxValue: number;
   funnelWidth: number;
   funnelHeight: number;
   isRTL: boolean;
 }): FunnelSegmentGeometry {
   const segmentWidth = funnelWidth / data.length;
-  const heightScale = (value: number) => (value / Math.max(...data.map(dp => dp.value))) * funnelHeight;
+  const heightScale = (value: number) => (value / maxValue) * funnelHeight;
   const leftHeight = heightScale(d.value);
   const rightHeight = i < data.length - 1 ? heightScale(data[i + 1].value) : 0;
   const yOffset = (funnelHeight - leftHeight) / 2;

--- a/packages/charts/chart-web-components/src/funnel-chart/funnelGeometry.ts
+++ b/packages/charts/chart-web-components/src/funnel-chart/funnelGeometry.ts
@@ -1,0 +1,314 @@
+import type { FunnelDataPoint, FunnelSubValue } from './funnel-chart.options.js';
+
+export interface FunnelSegmentGeometry {
+  pathD: string;
+  textX: number;
+  textY: number;
+  availableWidth: number;
+}
+
+interface SubValue {
+  category: string;
+  value: number;
+  color: string;
+}
+
+interface Stage {
+  subValues: SubValue[];
+}
+
+export function getVerticalFunnelSegmentGeometry({
+  d,
+  i,
+  data,
+  funnelWidth,
+  funnelHeight,
+  isRTL,
+}: {
+  d: FunnelDataPoint;
+  i: number;
+  data: FunnelDataPoint[];
+  funnelWidth: number;
+  funnelHeight: number;
+  isRTL: boolean;
+}): FunnelSegmentGeometry {
+  const segmentHeight = funnelHeight / data.length;
+  const widthScale = (value: number) => (value / Math.max(...data.map(dp => dp.value!))) * funnelWidth;
+  const topWidth = widthScale(d.value!);
+  const bottomWidth = i < data.length - 1 ? widthScale(data[i + 1].value!) : 0;
+  const xOffset = (funnelWidth - topWidth) / 2;
+  const nextXOffset = (funnelWidth - bottomWidth) / 2;
+  const xStart = isRTL ? funnelWidth - xOffset : xOffset;
+  const xEnd = isRTL ? funnelWidth - nextXOffset : nextXOffset;
+
+  const isLastSegment = i === data.length - 1;
+  const textY = isLastSegment ? i * segmentHeight + segmentHeight * 0.33 : i * segmentHeight + segmentHeight / 2;
+  const textX = funnelWidth / 2;
+
+  let availableWidth: number;
+  if (isLastSegment) {
+    const yFromTop = textY - i * segmentHeight;
+    const widthAtY = topWidth * (1 - yFromTop / segmentHeight);
+    availableWidth = Math.max(widthAtY * 0.8, 0);
+  } else {
+    availableWidth = Math.min(topWidth, bottomWidth) * 0.9;
+  }
+
+  const pathD = `M${xStart},${i * segmentHeight}
+    L${funnelWidth - xStart},${i * segmentHeight}
+    L${funnelWidth - xEnd},${(i + 1) * segmentHeight}
+    L${xEnd},${(i + 1) * segmentHeight}
+    Z`;
+  return { pathD, textX, textY, availableWidth };
+}
+
+export function getHorizontalFunnelSegmentGeometry({
+  d,
+  i,
+  data,
+  funnelWidth,
+  funnelHeight,
+  isRTL,
+}: {
+  d: FunnelDataPoint;
+  i: number;
+  data: FunnelDataPoint[];
+  funnelWidth: number;
+  funnelHeight: number;
+  isRTL: boolean;
+}): FunnelSegmentGeometry {
+  const segmentWidth = funnelWidth / data.length;
+  const heightScale = (value: number) => (value / Math.max(...data.map(dp => dp.value!))) * funnelHeight;
+  const leftHeight = heightScale(d.value!);
+  const rightHeight = i < data.length - 1 ? heightScale(data[i + 1].value!) : 0;
+  const yOffset = (funnelHeight - leftHeight) / 2;
+  const nextYOffset = (funnelHeight - rightHeight) / 2;
+  const x0 = i * segmentWidth;
+  const x1 = (i + 1) * segmentWidth;
+
+  const isLastSegment = i === data.length - 1;
+  let textX: number;
+  let textY: number;
+  let availableWidth = segmentWidth * 0.8;
+
+  if (isLastSegment) {
+    textX = x0 + (x1 - x0) * 0.25;
+    textY = funnelHeight / 2;
+    const segmentArea = (leftHeight * segmentWidth) / 2;
+    if (leftHeight < 40 || segmentArea < 800) {
+      availableWidth = 0;
+    } else {
+      availableWidth = (x1 - x0) * 0.75 * 0.6;
+    }
+  } else {
+    textX = (x0 + x1) / 2;
+    textY = funnelHeight / 2;
+    const minHeight = Math.min(leftHeight, rightHeight);
+    availableWidth = minHeight > 20 ? segmentWidth * 0.8 : 0;
+  }
+
+  const pathD = `M${x0},${yOffset}
+    L${x1},${nextYOffset}
+    L${x1},${funnelHeight - nextYOffset}
+    L${x0},${funnelHeight - yOffset}
+    Z`;
+  return { pathD, textX, textY, availableWidth };
+}
+
+export function getStackedVerticalFunnelSegmentGeometry({
+  i,
+  k,
+  stages,
+  totals,
+  maxTotal,
+  funnelWidth,
+  funnelHeight,
+}: {
+  i: number;
+  k: number;
+  stages: Stage[];
+  totals: number[];
+  maxTotal: number;
+  funnelWidth: number;
+  funnelHeight: number;
+}): FunnelSegmentGeometry {
+  const segmentHeight = funnelHeight / stages.length;
+  const cur = stages[i];
+  const next = stages[i + 1] || { subValues: [] };
+  const curTotal = totals[i] || 1;
+  const nextTotal = totals[i + 1] || 0;
+
+  let cumTop = 0;
+  let cumBot = 0;
+  for (let idx = 0; idx < k; idx++) {
+    const v = cur.subValues[idx];
+    const vNext = next.subValues?.find((x: SubValue) => x.category === v.category);
+    cumTop += (v.value / curTotal) * (curTotal / maxTotal) * funnelWidth;
+    cumBot += (vNext ? vNext.value / nextTotal : 0) * (nextTotal / maxTotal) * funnelWidth;
+  }
+  const v = cur.subValues[k];
+  const vNext = next.subValues?.find((x: SubValue) => x.category === v.category);
+  const topW = (v.value / curTotal) * (curTotal / maxTotal) * funnelWidth;
+  const botW = (vNext ? vNext.value / nextTotal : 0) * (nextTotal / maxTotal) * funnelWidth;
+  const topStart = (funnelWidth - (curTotal / maxTotal) * funnelWidth) / 2 + cumTop;
+  const topEnd = topStart + topW;
+  const botStart = (funnelWidth - (nextTotal / maxTotal) * funnelWidth) / 2 + cumBot;
+  const botEnd = botStart + botW;
+  const textX = (topStart + topEnd + botStart + botEnd) / 4;
+
+  const isLastSegment = i === stages.length - 1;
+  const textY = isLastSegment ? i * segmentHeight + segmentHeight * 0.33 : (i + 0.5) * segmentHeight;
+
+  let availableWidth: number;
+  if (isLastSegment) {
+    const yFromTop = textY - i * segmentHeight;
+    availableWidth = topW * (1 - yFromTop / segmentHeight);
+  } else {
+    availableWidth = Math.min(topW, botW);
+  }
+
+  const pathD = `M${topStart},${i * segmentHeight}
+    L${topEnd},${i * segmentHeight}
+    L${botEnd},${(i + 1) * segmentHeight}
+    L${botStart},${(i + 1) * segmentHeight}
+    Z`;
+  return { pathD, textX, textY, availableWidth };
+}
+
+export function getStackedHorizontalFunnelSegmentGeometry({
+  i,
+  k,
+  stages,
+  totals,
+  maxTotal,
+  funnelWidth,
+  funnelHeight,
+}: {
+  i: number;
+  k: number;
+  stages: Stage[];
+  totals: number[];
+  maxTotal: number;
+  funnelWidth: number;
+  funnelHeight: number;
+}): FunnelSegmentGeometry {
+  const segmentWidth = funnelWidth / stages.length;
+  const cur = stages[i];
+  const next = stages[i + 1] || { subValues: [] };
+  const curTotal = totals[i] || 1;
+  const nextTotal = totals[i + 1] || 0;
+
+  let cumTop = 0;
+  let cumBot = 0;
+  for (let idx = 0; idx < k; idx++) {
+    const v = cur.subValues[idx];
+    const vNext = next.subValues?.find((x: SubValue) => x.category === v.category);
+    cumTop += (v.value / curTotal) * (curTotal / maxTotal) * funnelHeight;
+    cumBot += (vNext ? vNext.value / nextTotal : 0) * (nextTotal / maxTotal) * funnelHeight;
+  }
+  const v = cur.subValues[k];
+  const vNext = next.subValues?.find((x: SubValue) => x.category === v.category);
+  const topH = (v.value / curTotal) * (curTotal / maxTotal) * funnelHeight;
+  const botH = (vNext ? vNext.value / nextTotal : 0) * (nextTotal / maxTotal) * funnelHeight;
+  const leftStart = i * segmentWidth;
+  const leftEnd = (i + 1) * segmentWidth;
+  const topStart = (funnelHeight - (curTotal / maxTotal) * funnelHeight) / 2 + cumTop;
+  const topEnd = topStart + topH;
+  const botStart = (funnelHeight - (nextTotal / maxTotal) * funnelHeight) / 2 + cumBot;
+  const botEnd = botStart + botH;
+
+  const isLastSegment = i === stages.length - 1;
+  let textX: number;
+  let textY: number;
+  let availableWidth: number;
+
+  if (isLastSegment) {
+    textX = leftStart + (leftEnd - leftStart) * 0.25;
+    textY = (topStart + topEnd) / 2;
+    const segmentArea = (topH * segmentWidth) / 2;
+    availableWidth = topH < 24 || segmentArea < 600 ? 0 : (leftEnd - leftStart) * 0.5 * 0.8;
+  } else {
+    textX = (leftStart + leftEnd) / 2;
+    textY = (topStart + topEnd + botStart + botEnd) / 4;
+    const avgHeight = (topH + botH) / 2;
+    availableWidth = avgHeight < 20 ? 0 : Math.abs(leftEnd - leftStart) * 0.9;
+  }
+
+  const pathD = `M${leftStart},${topStart}
+    L${leftEnd},${botStart}
+    L${leftEnd},${botEnd}
+    L${leftStart},${topEnd}
+    Z`;
+  return { pathD, textX, textY, availableWidth };
+}
+
+/**
+ * Computes whether segment value text should be shown and at what position.
+ */
+export function getSegmentTextProps({
+  availableWidth,
+  minTextWidth = 24,
+  textX,
+  textY,
+  value,
+}: {
+  availableWidth: number;
+  minTextWidth?: number;
+  textX: number;
+  textY: number;
+  value: number;
+}): {
+  show: boolean;
+  x: number;
+  y: number;
+  value: number;
+} {
+  return {
+    show: availableWidth > minTextWidth && availableWidth > 0,
+    x: textX,
+    y: textY,
+    value,
+  };
+}
+
+/**
+ * Returns a contrasting text color (black or white) for a given hex fill color.
+ */
+export function getContrastTextColor(hexColor: string): string {
+  if (!hexColor || !hexColor.startsWith('#')) {
+    return '#000000';
+  }
+  const normalized = hexColor.replace('#', '');
+  if (normalized.length !== 6) {
+    return '#000000';
+  }
+  const toLinear = (c: number) => (c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4));
+  const r = toLinear(parseInt(normalized.slice(0, 2), 16) / 255);
+  const g = toLinear(parseInt(normalized.slice(2, 4), 16) / 255);
+  const b = toLinear(parseInt(normalized.slice(4, 6), 16) / 255);
+  const luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  return luminance > 0.179 ? '#000000' : '#ffffff';
+}
+
+/**
+ * Returns true when the data array uses stacked sub-values for every stage.
+ */
+export function isStackedFunnelData(data: FunnelDataPoint[]): boolean {
+  return Array.isArray(data) && data.length > 0 && data.every(stage => Array.isArray(stage.subValues));
+}
+
+/**
+ * Returns the stage geometry params for stacked mode.
+ */
+export function buildStackedGeometryParams(data: FunnelDataPoint[]): {
+  stages: Array<{ subValues: SubValue[] }>;
+  totals: number[];
+  maxTotal: number;
+} {
+  const stages = data.map(s => ({
+    subValues: (s.subValues ?? []) as SubValue[],
+  }));
+  const totals = stages.map(s => s.subValues.reduce((sum, sv) => sum + sv.value, 0));
+  const maxTotal = Math.max(...totals);
+  return { stages, totals, maxTotal };
+}

--- a/packages/charts/chart-web-components/src/funnel-chart/index.ts
+++ b/packages/charts/chart-web-components/src/funnel-chart/index.ts
@@ -1,0 +1,5 @@
+export { definition as FunnelChartDefinition } from './funnel-chart.definition.js';
+export { FunnelChart } from './funnel-chart.js';
+export type { FunnelDataPoint, FunnelOrientation, FunnelSubValue } from './funnel-chart.options.js';
+export { styles as FunnelChartStyles } from './funnel-chart.styles.js';
+export { template as FunnelChartTemplate } from './funnel-chart.template.js';

--- a/packages/charts/chart-web-components/src/index-rollup.ts
+++ b/packages/charts/chart-web-components/src/index-rollup.ts
@@ -1,3 +1,4 @@
 import './horizontal-bar-chart/define.js';
 import './horizontal-bar-chart-with-axis/define.js';
 import './donut-chart/define.js';
+import './funnel-chart/define.js';

--- a/packages/charts/chart-web-components/src/index.ts
+++ b/packages/charts/chart-web-components/src/index.ts
@@ -20,3 +20,10 @@ export {
   HorizontalBarChartWithAxisStyles,
   HorizontalBarChartWithAxisTemplate,
 } from './horizontal-bar-chart-with-axis/index.js';
+export {
+  FunnelChart,
+  FunnelChartDefinition,
+  FunnelChartStyles,
+  FunnelChartTemplate,
+} from './funnel-chart/index.js';
+export type { FunnelDataPoint, FunnelOrientation, FunnelSubValue } from './funnel-chart/index.js';


### PR DESCRIPTION
## Summary

Adds a new `fluent-funnel-chart` web component to the `@fluentui/chart-web-components` package, following the patterns established by `DonutChart`, `HorizontalBarChart`, and `HorizontalBarChartWithAxis`.

## What's new

### New component: `FunnelChart` (`fluent-funnel-chart`)

**Files added** in `packages/charts/chart-web-components/src/funnel-chart/`:

| File | Purpose |
|------|---------|
| `funnel-chart.ts` | Main component class extending `ChartBase` |
| `funnel-chart.options.ts` | Public types: `FunnelDataPoint`, `FunnelSubValue`, `FunnelOrientation` |
| `funnel-chart.template.ts` | FAST HTML template (SVG container + legend + tooltip) |
| `funnel-chart.styles.ts` | CSS (segments, text, inactive/focus states, tooltip) |
| `funnel-chart.definition.ts` | `FunnelChart.compose(...)` with tag name `fluent-funnel-chart` |
| `define.ts` | Auto-registers via `FluentDesignSystem.registry` |
| `funnelGeometry.ts` | React-free port of geometry math from `react-charts` |
| `funnel-chart.stories.ts` | 8 Storybook stories (Basic, Horizontal, Stacked, RTL, Culture, etc.) |
| `funnel-chart.spec.ts` | Playwright integration tests |
| `funnel-chart.bench.ts` | Benchmark file |
| `index.ts` | Barrel exports |

**Files modified:**
- `src/index.ts` — added FunnelChart exports
- `src/index-rollup.ts` — added `import './funnel-chart/define.js'`

## Component features

- **`@attr width`** / **`@attr height`** — explicit sizing (like DonutChart, no ResizeObserver)
- **`@attr data`** — JSON array of `FunnelDataPoint[]` (simple or stacked with `subValues`)
- **`@attr orientation`** — `'vertical'` (default) | `'horizontal'`
- **Full ChartBase integration**: legend system, tooltip, RTL, culture/locale, accessibility (ARIA), keyboard navigation, theme tokens
- **Stacked funnel support**: automatically detected when all stages have `subValues`
- **Geometry logic**: ported from `packages/charts/react-charts/library/src/components/FunnelChart/funnelGeometry.ts`
- **Contrast text**: WCAG-based `getContrastTextColor` ensures readable labels on any segment fill

## Verification

- ✅ TypeScript: `tsc --noEmit` → exit 0
- ✅ Lint: no errors in new files (pre-existing errors in other chart files unchanged)
- ✅ `src/index-rollup.ts` updated for rollup bundle inclusion